### PR TITLE
Allow empty multiline blocks and whitespace-only cue payload lines.

### DIFF
--- a/src/vtt.rs
+++ b/src/vtt.rs
@@ -911,7 +911,7 @@ impl Display for VttTimings {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct VttTimestamp {
     /// The hours.
-    pub hours: u8,
+    pub hours: u32,
     /// The minutes.
     pub minutes: u8,
     /// The seconds.
@@ -949,7 +949,7 @@ impl From<Duration> for VttTimestamp {
         let seconds = duration.as_secs();
         let milliseconds = duration.subsec_millis() as u16;
 
-        let hours = (seconds / 3600) as u8;
+        let hours = (seconds / 3600) as u32;
         let minutes = ((seconds % 3600) / 60) as u8;
         let seconds = (seconds % 60) as u8;
 

--- a/src/vtt_parser.rs
+++ b/src/vtt_parser.rs
@@ -120,7 +120,7 @@ peg::parser! {
 
         /// Multiple lines.
         rule multiline() -> Vec<String>
-            = lines:$(!(whitespace()+ newline()) (!newline() [_])+ newline()) ** ()
+            = lines:$((!newline() [_])+ newline()) ** ()
             {
                 lines
                     .iter()
@@ -908,6 +908,31 @@ mod test {
                 },
                 settings: None,
                 payload: vec![],
+            }
+        );
+
+        // Includes whitespace-only line.
+        assert_eq!(
+            vtt_parser::cue("00:00:00.000 --> 00:00:01.000\nHello, world!\n \n")
+                .unwrap(),
+            VttCue {
+                identifier: None,
+                timings: VttTimings {
+                    start: VttTimestamp {
+                        hours: 0,
+                        minutes: 0,
+                        seconds: 0,
+                        milliseconds: 0,
+                    },
+                    end: VttTimestamp {
+                        hours: 0,
+                        minutes: 0,
+                        seconds: 1,
+                        milliseconds: 0,
+                    },
+                },
+                settings: None,
+                payload: vec!["Hello, world!".to_string(), "".to_string()],
             }
         );
 

--- a/src/vtt_parser.rs
+++ b/src/vtt_parser.rs
@@ -294,7 +294,7 @@ peg::parser! {
         /// Minimal cue block
         rule cue_minimal() -> VttCue
             = whitespace()* timings:timings() whitespace()* newline()
-                whitespace()* payload:multiline()
+                payload:multiline()
             {
                 VttCue {
                     identifier: None,
@@ -308,7 +308,7 @@ peg::parser! {
         rule cue_with_identifier() -> VttCue
             = whitespace()* identifier:line()
                 whitespace()* timings:timings() whitespace()* newline()
-                whitespace()* payload:multiline()
+                payload:multiline()
             {
                 VttCue {
                     identifier: Some(identifier),
@@ -321,7 +321,7 @@ peg::parser! {
         /// Cue block with settings.
         rule cue_with_settings() -> VttCue
             = whitespace()* timings:timings() whitespace()+ settings:cue_settings() whitespace()* newline()
-                whitespace()* payload:multiline()
+                payload:multiline()
             {
                 VttCue {
                     identifier: None,
@@ -335,7 +335,7 @@ peg::parser! {
         rule cue_with_identifier_and_settings() -> VttCue
             = whitespace()* identifier:line()
                 whitespace()* timings:timings() whitespace()+ settings:cue_settings() whitespace()* newline()
-                whitespace()* payload:multiline()
+                payload:multiline()
             {
                 VttCue {
                     identifier: Some(identifier),
@@ -911,7 +911,32 @@ mod test {
             }
         );
 
-        // Includes whitespace-only line.
+        // Includes leading whitespace-only line.
+        assert_eq!(
+            vtt_parser::cue("00:00:00.000 --> 00:00:01.000\n \nHello, world!\n")
+                .unwrap(),
+            VttCue {
+                identifier: None,
+                timings: VttTimings {
+                    start: VttTimestamp {
+                        hours: 0,
+                        minutes: 0,
+                        seconds: 0,
+                        milliseconds: 0,
+                    },
+                    end: VttTimestamp {
+                        hours: 0,
+                        minutes: 0,
+                        seconds: 1,
+                        milliseconds: 0,
+                    },
+                },
+                settings: None,
+                payload: vec!["".to_string(), "Hello, world!".to_string()],
+            }
+        );
+
+        // Includes trailing whitespace-only line.
         assert_eq!(
             vtt_parser::cue("00:00:00.000 --> 00:00:01.000\nHello, world!\n \n")
                 .unwrap(),


### PR DESCRIPTION
Fixes #2, #4, #5

Note that this also allows empty comments, and "below"-style comments that begin with whitespace, neither of which are forbidden by the spec: https://www.w3.org/TR/webvtt1/#introduction-comments